### PR TITLE
Hide bottom action group when upload modal opens

### DIFF
--- a/src/components/feed/bottom-action-group.tsx
+++ b/src/components/feed/bottom-action-group.tsx
@@ -2,6 +2,7 @@
 
 import { motion, useReducedMotion } from "motion/react";
 import { useExpansion } from "@/components/expanded/expansion-context";
+import { useUploadModal } from "@/components/upload/upload-modal-context";
 import { SPRING, INSTANT } from "@/lib/motion";
 import { FeedSearchTrigger } from "./feed-search-trigger";
 import { SendItButton } from "./send-it-button";
@@ -17,8 +18,9 @@ const HIDE_OFFSET_PX = 200;
  */
 export function BottomActionGroup() {
   const { postData } = useExpansion();
+  const { isOpen: uploadOpen } = useUploadModal();
   const reducedMotion = useReducedMotion();
-  const hidden = !!postData;
+  const hidden = !!postData || uploadOpen;
 
   return (
     <motion.div


### PR DESCRIPTION
## Summary

The search button (magnifying-glass circle) was showing in front of the SEND IT upload modal's dark backdrop instead of being covered by it.

Root cause: `BottomActionGroup` sits at `z-50`, the upload modal dialog root at `z-40` — per the documented z-index scale. The group already springs off-screen when a post overlay expands, but had no equivalent behavior for the upload modal, so the search button stayed visible above the backdrop.

Fix: extend the existing `hidden` boolean to also watch `useUploadModal().isOpen`. Reuses the same spring + transform the post-expand case already uses — two-line diff.

The `SendItButton` itself was already hiding its own container on `isOpen`, so with this change both buttons disappear together when the modal opens.

## Test plan

- [x] Open `/feed` and click SEND IT → confirm search button is no longer visible behind/in front of the modal backdrop (verified via preview in worktree: `transform: matrix(..., 200)` pushes the group off-screen, `aria-hidden="true"`)
- [ ] Close the modal → both buttons spring back into place
- [ ] Open an expanded post → both buttons still hide as before (regression check)
- [ ] With a post expanded, clicking SEND IT still works (upload context collapses the post first)
- [ ] Reduced-motion: snap-to-hidden instead of spring

🤖 Generated with [Claude Code](https://claude.com/claude-code)