### PR TITLE
Align portrait media bottom with stacked landscape media

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "Next.js dev",
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     },
     {
       "name": "Vitest UI",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@ Two route groups under `src/app/`:
 - See `docs/solutions/ui-bugs/` and `docs/brainstorms/2026-04-10-infinite-loop-scroll-brainstorm.md` for prior work on this.
 
 `FeedGrid`:
-- 3-column dense grid, `perspective: 1000px`. Portrait posts (`height > width`) span 2 rows.
+- 3-column dense grid, `perspective: 1000px`. Each card is a subgrid — landscapes span 2 parent rows (media + caption track), portraits span 4 (2 media tracks + 2 caption tracks, with the portrait's media spanning rows 1–3). This makes the portrait media bottom align exactly with the media bottom of the landscape stacked next to it, regardless of caption wrap.
+- Because of subgrid, each card's motion.div is the direct grid child (no wrapper `<div>`), and media↔caption gap = parent `gap-6` (24px), not `gap-4`.
 - Stagger delays computed by `computeStaggerDelays` (80ms within row, 60ms extra between rows).
 - IntersectionObserver sentinel (`rootMargin: 400px`) drives infinite-scroll fetch.
 

--- a/src/components/feed/experiment-card.tsx
+++ b/src/components/feed/experiment-card.tsx
@@ -117,7 +117,7 @@ export function ExperimentCard({
   const caption = post.body?.slice(0, 120) || post.title;
   const commentCount = post.comments?.[0]?.count ?? 0;
 
-  const aspectRatio = orientation === "portrait" ? "2/3" : "3/2";
+  const isPortrait = orientation === "portrait";
 
   // This card is currently expanded — hide it but keep its space
   const isLifted = postData?.id === post.id;
@@ -160,8 +160,10 @@ export function ExperimentCard({
     <motion.div
       onMouseEnter={handlePreloadIntent}
       onPointerDown={handlePreloadIntent}
+      className="grid grid-rows-[subgrid]"
       style={{
         transformStyle: "preserve-3d",
+        gridRow: isPortrait ? "span 4" : "span 2",
       }}
       initial={
         reducedMotion
@@ -205,39 +207,40 @@ export function ExperimentCard({
       <motion.div
         layoutId={`card-${post.id}`}
         onClick={handleClick}
-        className="group block cursor-pointer !rounded-none !overflow-visible"
-        style={{ opacity: isLifted ? 0 : 1 }}
+        className="group cursor-pointer !rounded-none !overflow-visible grid grid-rows-[subgrid]"
+        style={{
+          opacity: isLifted ? 0 : 1,
+          gridRow: isPortrait ? "span 4" : "span 2",
+        }}
         transition={{ layout: SPRING.default }}
       >
-        <div className="flex flex-col gap-4">
-          <PostMedia
-            videoUrl={videoUrl}
-            thumbnailUrl={thumbnailUrl}
-            videoPosterUrl={firstVideoAsset?.poster_signed_url}
-            videoRef={feedVideoRef}
-            thumbHash={displayAsset?.thumb_hash}
-            dominantColor={displayAsset?.dominant_color}
-            aspectRatio={aspectRatio}
-            alt={post.title}
-            imageClassName="transition-all duration-500 ease-out group-hover:scale-[1.02]"
-          />
+        <PostMedia
+          videoUrl={videoUrl}
+          thumbnailUrl={thumbnailUrl}
+          videoPosterUrl={firstVideoAsset?.poster_signed_url}
+          videoRef={feedVideoRef}
+          thumbHash={displayAsset?.thumb_hash}
+          dominantColor={displayAsset?.dominant_color}
+          aspectRatio={isPortrait ? undefined : "3/2"}
+          containerClassName={isPortrait ? "row-[span_3] min-h-0" : undefined}
+          alt={post.title}
+          imageClassName="transition-all duration-500 ease-out group-hover:scale-[1.02]"
+        />
 
-          {/* Caption row */}
-          <div className="flex items-baseline gap-2">
-            <AuthorPill authorName={authorName} backgroundColor={badgeColor} />
-            <p className="min-w-0 flex-1 text-heading-base text-[var(--text-caption)]">
-              {caption}
-            </p>
-            {commentCount > 0 && (
-              <span
-                className="inline-flex shrink-0 items-center gap-1 font-heading text-sm tracking-[-0.14px] text-[var(--text-caption)]"
-                aria-label={`${commentCount} comment${commentCount === 1 ? "" : "s"}`}
-              >
-                <MessageCircleIcon className="size-3.5" aria-hidden="true" />
-                {commentCount}
-              </span>
-            )}
-          </div>
+        <div className="flex items-baseline gap-2">
+          <AuthorPill authorName={authorName} backgroundColor={badgeColor} />
+          <p className="min-w-0 flex-1 text-heading-base text-[var(--text-caption)]">
+            {caption}
+          </p>
+          {commentCount > 0 && (
+            <span
+              className="inline-flex shrink-0 items-center gap-1 font-heading text-sm tracking-[-0.14px] text-[var(--text-caption)]"
+              aria-label={`${commentCount} comment${commentCount === 1 ? "" : "s"}`}
+            >
+              <MessageCircleIcon className="size-3.5" aria-hidden="true" />
+              {commentCount}
+            </span>
+          )}
         </div>
       </motion.div>
     </motion.div>

--- a/src/components/feed/feed-grid.tsx
+++ b/src/components/feed/feed-grid.tsx
@@ -86,25 +86,14 @@ export function FeedGrid({ posts, hasMore, loading, onLoadMore }: FeedGridProps)
           transformStyle: "preserve-3d",
         }}
       >
-        {posts.map((post, i) => {
-          const orientation = orientations[i];
-          const isPortrait = orientation === "portrait";
-          return (
-            <div
-              key={post.id}
-              style={{
-                ...(isPortrait ? { gridRow: "span 2" } : {}),
-                transformStyle: "preserve-3d",
-              }}
-            >
-              <ExperimentCard
-                post={post}
-                orientation={orientation}
-                delay={delays[i]}
-              />
-            </div>
-          );
-        })}
+        {posts.map((post, i) => (
+          <ExperimentCard
+            key={post.id}
+            post={post}
+            orientation={orientations[i]}
+            delay={delays[i]}
+          />
+        ))}
 
         {loading &&
           Array.from({ length: 3 }).map((_, i) => (

--- a/src/components/feed/inert-card.tsx
+++ b/src/components/feed/inert-card.tsx
@@ -40,7 +40,7 @@ export function InertCard({ post, orientation }: InertCardProps) {
   const badgeColor = getAuthorColor(authorName, post.author?.color);
   const caption = post.body?.slice(0, 120) || post.title;
   const commentCount = post.comments?.[0]?.count ?? 0;
-  const aspectRatio = orientation === "portrait" ? "2/3" : "3/2";
+  const isPortrait = orientation === "portrait";
 
   const layoutId = `buffer-${post.id}`;
   const isLifted = postData?.id === post.id;
@@ -82,36 +82,38 @@ export function InertCard({ post, orientation }: InertCardProps) {
       onClick={handleClick}
       onMouseEnter={handlePreloadIntent}
       onPointerDown={handlePreloadIntent}
-      className="group block cursor-pointer !rounded-none !overflow-visible"
-      style={{ opacity: isLifted ? 0 : 1 }}
+      className="group cursor-pointer !rounded-none !overflow-visible grid grid-rows-[subgrid]"
+      style={{
+        opacity: isLifted ? 0 : 1,
+        gridRow: isPortrait ? "span 4" : "span 2",
+      }}
       transition={{ layout: SPRING.default }}
     >
-      <div className="flex flex-col gap-4">
-        <PostMedia
-          videoUrl={videoUrl}
-          thumbnailUrl={thumbnailUrl}
-          videoPosterUrl={firstVideoAsset?.poster_signed_url}
-          videoRef={feedVideoRef}
-          dominantColor={displayAsset?.dominant_color}
-          aspectRatio={aspectRatio}
-          imageClassName="transition-transform duration-300 group-hover:scale-[1.02]"
-        />
+      <PostMedia
+        videoUrl={videoUrl}
+        thumbnailUrl={thumbnailUrl}
+        videoPosterUrl={firstVideoAsset?.poster_signed_url}
+        videoRef={feedVideoRef}
+        dominantColor={displayAsset?.dominant_color}
+        aspectRatio={isPortrait ? undefined : "3/2"}
+        containerClassName={isPortrait ? "row-[span_3] min-h-0" : undefined}
+        imageClassName="transition-transform duration-300 group-hover:scale-[1.02]"
+      />
 
-        <div className="flex items-baseline gap-2">
-          <AuthorPill authorName={authorName} backgroundColor={badgeColor} />
-          <p className="min-w-0 flex-1 text-heading-base text-[var(--text-caption)]">
-            {caption}
-          </p>
-          {commentCount > 0 && (
-            <span
-              className="inline-flex shrink-0 items-center gap-1 font-heading text-sm tracking-[-0.14px] text-[var(--text-caption)]"
-              aria-label={`${commentCount} comment${commentCount === 1 ? "" : "s"}`}
-            >
-              <MessageCircleIcon className="size-3.5" aria-hidden="true" />
-              {commentCount}
-            </span>
-          )}
-        </div>
+      <div className="flex items-baseline gap-2">
+        <AuthorPill authorName={authorName} backgroundColor={badgeColor} />
+        <p className="min-w-0 flex-1 text-heading-base text-[var(--text-caption)]">
+          {caption}
+        </p>
+        {commentCount > 0 && (
+          <span
+            className="inline-flex shrink-0 items-center gap-1 font-heading text-sm tracking-[-0.14px] text-[var(--text-caption)]"
+            aria-label={`${commentCount} comment${commentCount === 1 ? "" : "s"}`}
+          >
+            <MessageCircleIcon className="size-3.5" aria-hidden="true" />
+            {commentCount}
+          </span>
+        )}
       </div>
     </motion.div>
   );

--- a/src/components/feed/loop-scroll-container.tsx
+++ b/src/components/feed/loop-scroll-container.tsx
@@ -126,18 +126,13 @@ const BufferGrid = forwardRef<HTMLDivElement, BufferGridProps>(
         className={`grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3${className ? ` ${className}` : ""}`}
         style={{ gridAutoFlow: "dense", perspective: "1000px" }}
       >
-        {posts.map((post) => {
-          const orientation = getPostOrientation(post);
-          const isPortrait = orientation === "portrait";
-          return (
-            <div
-              key={`${keyPrefix}-${post.id}`}
-              style={isPortrait ? { gridRow: "span 2" } : undefined}
-            >
-              <InertCard post={post} orientation={orientation} />
-            </div>
-          );
-        })}
+        {posts.map((post) => (
+          <InertCard
+            key={`${keyPrefix}-${post.id}`}
+            post={post}
+            orientation={getPostOrientation(post)}
+          />
+        ))}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- Portrait feed cards now have their media bottom exactly flush with the media bottom of the second landscape card stacked next to them, regardless of how many lines either caption wraps to.
- Achieved via CSS subgrid: each card spans the parent's media and caption row tracks, so they align across the whole grid.

## Why
Previously, portrait media used a hard-coded `aspectRatio: "2/3"`, so its height depended only on column width — never on the neighboring landscape cards. When landscape captions wrapped to different line counts, the portrait media ended noticeably higher than the landscape below it. The fix replaces that with a shared track system so the alignment is driven by the actual rendered layout.

## How it works
- Landscape card → `grid-row: span 2` subgrid → media in track 1 (aspect 3/2), caption in track 2.
- Portrait card → `grid-row: span 4` subgrid → media spans tracks 1–3, caption in track 4.
- Parent row tracks are sized by the landscape cards' intrinsic content; portrait media (`min-h-0`, no aspect-ratio) stretches to fill its span.

## Notable side effects
- Each card's `motion.div` is now the direct grid child — the wrapper `<div>` in `FeedGrid` and `BufferGrid` was removed because subgrid only inherits tracks from the nearest grid ancestor.
- Media↔caption gap within a card is now `24px` (parent `gap-6`) instead of `16px`. Subgrid inherits the parent's row-gap.

## Files
- `src/components/feed/experiment-card.tsx`, `src/components/feed/inert-card.tsx` — subgrid + row-span.
- `src/components/feed/feed-grid.tsx`, `src/components/feed/loop-scroll-container.tsx` — remove wrapper `<div>`s.
- `CLAUDE.md` — document the new grid model.
- `.claude/launch.json` — `autoPort: true` so the preview server can coexist with another dev server on port 3000.

## Test plan
- [ ] Load `/feed` on localhost; confirm a portrait card's media bottom aligns with the media bottom of the second landscape card in the adjacent column (not the caption bottom).
- [ ] Find a row where the two landscape captions wrap differently (e.g. 1 line vs 2 lines). Confirm alignment still holds.
- [ ] Click a portrait card; FLIP expansion still animates from the correct bounding box.
- [ ] Scroll past the 40svh spacer to trigger `LoopScrollContainer`; confirm `BufferGrid` portraits render identically to the main grid and the teleport remains seamless.
- [ ] Toggle reduced-motion at the OS level; feed still lays out correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)