### PR TITLE
Spring search button out from under SEND IT on modal close

### DIFF
--- a/src/components/feed/bottom-action-group.tsx
+++ b/src/components/feed/bottom-action-group.tsx
@@ -2,7 +2,6 @@
 
 import { motion, useReducedMotion } from "motion/react";
 import { useExpansion } from "@/components/expanded/expansion-context";
-import { useUploadModal } from "@/components/upload/upload-modal-context";
 import { SPRING, INSTANT } from "@/lib/motion";
 import { FeedSearchTrigger } from "./feed-search-trigger";
 import { SendItButton } from "./send-it-button";
@@ -18,9 +17,8 @@ const HIDE_OFFSET_PX = 200;
  */
 export function BottomActionGroup() {
   const { postData } = useExpansion();
-  const { isOpen: uploadOpen } = useUploadModal();
   const reducedMotion = useReducedMotion();
-  const hidden = !!postData || uploadOpen;
+  const hidden = !!postData;
 
   return (
     <motion.div

--- a/src/components/feed/feed-search-trigger.tsx
+++ b/src/components/feed/feed-search-trigger.tsx
@@ -1,33 +1,44 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { motion } from "motion/react";
 import { SearchIcon } from "lucide-react";
 import { useSearchPalette } from "./search-context";
 import { useUploadModal } from "@/components/upload/upload-modal-context";
+import { SPRING } from "@/lib/motion";
+
+// Hidden state tucks the search button behind the SEND IT pill so the
+// reveal reads as "emerging out from under" send-it.
+const HIDDEN_OFFSET_X = 32;
+// Return delay so send-it's own collapse animation lands before search
+// starts springing out from behind it.
+const RETURN_DELAY_S = 0.45;
 
 export function FeedSearchTrigger() {
   const { open } = useSearchPalette();
   const { isOpen: uploadOpen } = useUploadModal();
-  const [entered, setEntered] = useState(false);
-
-  useEffect(() => setEntered(true), []);
-
-  const hidden = !entered || uploadOpen;
 
   return (
-    <button
+    <motion.button
       type="button"
       onClick={open}
       aria-label="Search experiments (⌘K)"
       aria-keyshortcuts="Meta+K Control+K"
-      className={`flex size-12 cursor-pointer items-center justify-center rounded-full bg-[var(--text-dark)] transition-[opacity,transform] duration-500 ease-out ${
-        hidden
-          ? "pointer-events-none translate-y-3 opacity-0"
-          : "pointer-events-auto translate-y-0 opacity-100"
+      className={`relative z-[-1] flex size-12 cursor-pointer items-center justify-center rounded-full bg-[var(--text-dark)] ${
+        uploadOpen ? "pointer-events-none" : "pointer-events-auto"
       }`}
-      aria-hidden={hidden}
+      initial={{ opacity: 0, x: HIDDEN_OFFSET_X }}
+      animate={uploadOpen ? "hidden" : "visible"}
+      variants={{
+        visible: { opacity: 1, x: 0 },
+        hidden: { opacity: 0, x: HIDDEN_OFFSET_X },
+      }}
+      transition={{
+        ...SPRING.default,
+        delay: uploadOpen ? 0 : RETURN_DELAY_S,
+      }}
+      aria-hidden={uploadOpen}
     >
       <SearchIcon className="size-5 text-[var(--page-bg)]" aria-hidden="true" />
-    </button>
+    </motion.button>
   );
 }

--- a/src/components/feed/feed-search-trigger.tsx
+++ b/src/components/feed/feed-search-trigger.tsx
@@ -1,25 +1,33 @@
 "use client";
 
-import { motion } from "motion/react";
+import { useEffect, useState } from "react";
 import { SearchIcon } from "lucide-react";
 import { useSearchPalette } from "./search-context";
-import { SPRING } from "@/lib/motion";
+import { useUploadModal } from "@/components/upload/upload-modal-context";
 
 export function FeedSearchTrigger() {
   const { open } = useSearchPalette();
+  const { isOpen: uploadOpen } = useUploadModal();
+  const [entered, setEntered] = useState(false);
+
+  useEffect(() => setEntered(true), []);
+
+  const hidden = !entered || uploadOpen;
 
   return (
-    <motion.button
+    <button
       type="button"
       onClick={open}
       aria-label="Search experiments (⌘K)"
       aria-keyshortcuts="Meta+K Control+K"
-      className="pointer-events-auto flex size-12 cursor-pointer items-center justify-center rounded-full bg-[var(--text-dark)]"
-      initial={{ opacity: 0, y: 12 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={SPRING.default}
+      className={`flex size-12 cursor-pointer items-center justify-center rounded-full bg-[var(--text-dark)] transition-[opacity,transform] duration-500 ease-out ${
+        hidden
+          ? "pointer-events-none translate-y-3 opacity-0"
+          : "pointer-events-auto translate-y-0 opacity-100"
+      }`}
+      aria-hidden={hidden}
     >
       <SearchIcon className="size-5 text-[var(--page-bg)]" aria-hidden="true" />
-    </motion.button>
+    </button>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to #88 — the original fix dropped the whole bottom action group off-screen, which made modal close feel sluggish (200px bounce before send-it could reappear). This PR fixes that.

- `FeedSearchTrigger` animates independently with Motion springs; container stays stationary.
- On open: search fades + slides `x: 32` to tuck behind SEND IT (`z-[-1]` stacks it under the pill).
- On close: `transition.delay = 0.45s` so send-it's own collapse animation lands first, then search springs out from under.
- `BottomActionGroup` reverted to only hiding on post-expand (its original behavior).

## Test plan

- [x] Open SEND IT — search button fades + slides behind the pill (verified in worktree preview)
- [x] Close modal — send-it returns to initial state, then search springs out (delay + spring confirmed via DOM sampling)
- [ ] Regression: expand a post — bottom action group still hides as before
- [ ] Reduced-motion honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)